### PR TITLE
v4.2: fix Kagi desktop bullets (#21), selectAll menu leak (#22), mobile button height (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _All AIs in your corner, wherever you are._
 ![](docs/screenshots/iphone.gif)
 
 
-## Functionalities (v4.1)
+## Functionalities (v4.2)
 
 - **Floating Menu:** A draggable trigger icon (📟) provides access to all features.
 - **AI Integration:**
@@ -78,7 +78,8 @@ This applies to all contributors — human and AI agents alike.
 
 | Version | File | Key additions | Details |
 | ------- | ---- | ------------- | ------- |
-| 4.1 | `universal-bookmarklet-menu.user.js` | Options pane | - Added Options pane (⚙️) with trigger position setting (right/left/custom) and dark theme following toggle<br>- Position and theme preferences persist across sessions via `GM_setValue`<br>- Custom position saved automatically when dragging the trigger |
+| 4.2 | `universal-bookmarklet-menu.user.js` | Fixes for #21, #22, #23 | - Kagi Summarizer now uses `index.html` in the selection URL so desktop honors `summary=keypoints` (#21)<br>- `(selectAll)` keeps menu UI hidden until the bookmarklet reads the selection, so menu text no longer leaks into it (#22)<br>- Mobile trigger sits 100px higher (`bottom: 180px`) to clear mobile browser chrome (#23) |
+| 4.1 | `35 Universal Bookmarklet Menu-4.1.user.txt` | Options pane | - Added Options pane (⚙️) with trigger position setting (right/left/custom) and dark theme following toggle<br>- Position and theme preferences persist across sessions via `GM_setValue`<br>- Custom position saved automatically when dragging the trigger |
 | 4.0 | `34 Universal Bookmarklet Menu-4.0.user.txt` | Auto-updates, version display, CI releases | - Tampermonkey auto-update support via `@updateURL`/`@downloadURL`<br>- Version number and date shown in menu (bottom-left)<br>- Stable canonical filename for persistent update URLs<br>- GitHub Actions CI creates releases on version bumps<br>- Added `@connect` whitelist for Gemini API |
 | 3.3 | `33 Universal Bookmarklet Menu-3.3.user.txt` | Kagi Summarizer update | - Updated Kagi Summarizer parameter from `summary=takeaway` to `summary=keypoints` for all SUMMARIZE actions (button, selection, and basket) |
 | 3.2 | `32 Universal Bookmarklet Menu-3.2.user.txt` | Enhanced View Source | - Added page date display (Last Modified or Fetched date)<br>- Added syntax highlighting toggle for HTML source<br>- Added line wrap toggle for better readability |

--- a/previous-versions/35 Universal Bookmarklet Menu-4.1.user.txt
+++ b/previous-versions/35 Universal Bookmarklet Menu-4.1.user.txt
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Universal Bookmarklet Menu
 // @namespace    http://tampermonkey.net/
-// @version      4.2
+// @version      4.1
 // @description  Floating AI bookmarklet menu with auto-updates. Quick access to ChatGPT, Claude, Gemini, Kagi, and page utilities.
 // @author       Renato (with additions by AI)
 // @match        *://*/*
@@ -19,8 +19,8 @@
     'use strict';
 
     // --- Version Info ---
-    const SCRIPT_VERSION = '4.2';
-    const SCRIPT_DATE = '2026-04-22';
+    const SCRIPT_VERSION = '4.1';
+    const SCRIPT_DATE = '2026-03-28';
 
     // --- Helper for Status Messages (Generic Green/Red, Centered) ---
     function showStatusMessage(text, duration = 3000, isError = false) {
@@ -431,8 +431,7 @@
         code: function() {
             var selection = window.getSelection().toString().trim();
             if (selection) {
-                // Use index.html so Kagi's desktop UI consistently honors summary=keypoints (issue #21)
-                window.open("https://kagi.com/summarizer/index.html?target_language=&summary=keypoints#" + encodeURIComponent(selection), "_blank");
+                window.open("https://kagi.com/summarizer/?target_language=&summary=keypoints#" + encodeURIComponent(selection), "_blank");
             } else {
                 window.open("https://kagi.com/summarizer/index.html?target_language=&summary=keypoints&url=" + encodeURIComponent(location.href), "_blank");
             }
@@ -1061,19 +1060,12 @@ Current page title: ${document.title}`;
     menuTrigger.textContent = '📟';
     document.body.appendChild(menuTrigger);
 
-    // Mobile layout sits the trigger 100px higher to clear mobile browser
-    // chrome (URL bar, home indicator) — issue #23.
-    function getTriggerBottomOffsetPx() {
-        return window.matchMedia('(max-width: 768px)').matches ? 180 : 80;
-    }
-
     // --- Apply Settings ---
     function applyPositionSetting() {
         const pos = currentSettings.position;
-        const bottomPx = getTriggerBottomOffsetPx() + 'px';
         if (pos === 'left') {
             menuTrigger.style.right = 'auto';
-            menuTrigger.style.bottom = bottomPx;
+            menuTrigger.style.bottom = '80px';
             menuTrigger.style.left = '20px';
             menuTrigger.style.top = 'auto';
         } else if (pos === 'custom' && currentSettings.customX !== null && currentSettings.customY !== null) {
@@ -1086,7 +1078,7 @@ Current page title: ${document.title}`;
             menuTrigger.style.left = 'auto';
             menuTrigger.style.top = 'auto';
             menuTrigger.style.right = '20px';
-            menuTrigger.style.bottom = bottomPx;
+            menuTrigger.style.bottom = '80px';
         }
     }
 
@@ -1382,43 +1374,33 @@ Current page title: ${document.title}`;
         menuVisible = false;
     }
 
-    // Hardcoded unique IDs owned by this script. Used to exclude our own UI
-    // from the selectAll helper (issue #22).
-    const CUSTOM_BM_ELEMENT_IDS = [
-        'custom-bm-menu-trigger',
-        'custom-bm-menu-container',
-        'custom-bm-status-msg',
-        'custom-gemini-notification-box'
-    ];
-
-    // Helper function to select all text on the page. Returns a restore
-    // function (or null on failure). The restore function must be called
-    // AFTER the bookmarklet has read window.getSelection().toString() — if
-    // our menu elements are made visible again before that read, their
-    // text leaks into the selection (issue #22).
+    // Helper function to select all text on the page
     function selectAllPageText() {
         try {
             const selection = window.getSelection();
-            if (!selection) return null;
+            if (!selection) return false;
 
-            const elementsToHide = CUSTOM_BM_ELEMENT_IDS
-                .map(id => document.getElementById(id))
-                .filter(el => el);
+            // Temporarily hide our own elements to exclude them from selection
+            const menuTrigger = document.getElementById('custom-bm-menu-trigger');
+            const menuContainer = document.getElementById('custom-bm-menu-container');
+            const statusMsg = document.getElementById('custom-bm-status-msg');
+            const geminiNotification = document.getElementById('custom-gemini-notification-box');
+            const elementsToHide = [menuTrigger, menuContainer, statusMsg, geminiNotification].filter(el => el);
             const originalStyles = elementsToHide.map(el => el.style.display);
+            // Hide elements
             elementsToHide.forEach(el => el.style.display = 'none');
-
             const range = document.createRange();
             range.selectNodeContents(document.body);
-            selection.removeAllRanges();
-            selection.addRange(range);
+            selection.removeAllRanges(); // Clear any previous selection
+            selection.addRange(range); // Add the new range
 
-            return () => {
-                elementsToHide.forEach((el, i) => el.style.display = originalStyles[i]);
-            };
+            // Restore elements
+            elementsToHide.forEach((el, i) => el.style.display = originalStyles[i]);
+            return true;
         } catch (e) {
             console.error("Error selecting all text:", e);
             showStatusMessage("Could not select page text.", 3000, true);
-            return null;
+            return false;
         }
     }
 
@@ -1453,14 +1435,9 @@ Current page title: ${document.title}`;
                 event.preventDefault();
                 event.stopPropagation();
 
-                const restore = selectAllPageText();
-                if (restore) {
+                if (selectAllPageText()) {
                     setTimeout(() => {
-                        try {
-                            runBookmarkletAndHideMenu(bm);
-                        } finally {
-                            restore();
-                        }
+                        runBookmarkletAndHideMenu(bm);
                     }, 50);
                 }
             });
@@ -1768,12 +1745,6 @@ Current page title: ${document.title}`;
             -webkit-user-select: none; /* Safari */
             backdrop-filter: blur(4px); /* Enhanced frosted glass */
             transition: background-color 0.2s; /* Smooth hover effect - note: JS might override this temporarily */
-        }
-        /* Raise the trigger 100px on mobile to clear browser chrome (issue #23). */
-        @media (max-width: 768px) {
-            #custom-bm-menu-trigger {
-                bottom: 180px;
-            }
         }
         #custom-bm-menu-trigger:hover {
             background-color: var(--trigger-hover-bg);

--- a/universal-bookmarklet-menu.user.js
+++ b/universal-bookmarklet-menu.user.js
@@ -357,7 +357,7 @@
             // Open multiple Kagi summarizer tabs for each URL in basket
             basket.forEach((item, index) => {
                 setTimeout(() => {
-                    window.open("https://kagi.com/summarizer/index.html?target_language=&summary=keypoints&url=" + encodeURIComponent(item.url), "_blank");
+                    window.open("https://kagi.com/summarizer/index.html?summary=keypoints&target_language=&url=" + encodeURIComponent(item.url), "_blank");
                 }, index * 500); // Stagger opening to avoid browser blocking
             });
             showStatusMessage(`Opening ${basket.length} summarizer tabs...`, 3000);
@@ -431,10 +431,10 @@
         code: function() {
             var selection = window.getSelection().toString().trim();
             if (selection) {
-                // Use index.html so Kagi's desktop UI consistently honors summary=keypoints (issue #21)
-                window.open("https://kagi.com/summarizer/index.html?target_language=&summary=keypoints#" + encodeURIComponent(selection), "_blank");
+                // summary=keypoints must be the first query arg so Kagi's desktop UI honors it (issue #21)
+                window.open("https://kagi.com/summarizer/index.html?summary=keypoints&target_language=#" + encodeURIComponent(selection), "_blank");
             } else {
-                window.open("https://kagi.com/summarizer/index.html?target_language=&summary=keypoints&url=" + encodeURIComponent(location.href), "_blank");
+                window.open("https://kagi.com/summarizer/index.html?summary=keypoints&target_language=&url=" + encodeURIComponent(location.href), "_blank");
             }
         }
     }, {


### PR DESCRIPTION
Closes #21, closes #22, closes #23.

## Summary

- **#21 — Kagi bullet points on desktop:** Every Kagi Summarizer URL now leads with `summary=keypoints` as the first query arg (matching the mobile path that already worked) and uses `index.html` consistently. Fixes the desktop SUMMARIZE not applying the keypoints option. Affects the main SUMMARIZE (selection + no-selection) and the basket "Summarize Basket" action.
- **#22 — Menu excluded from selectAll:** Consolidated our UI element IDs into a single hardcoded `CUSTOM_BM_ELEMENT_IDS` list. `selectAllPageText()` now returns a restore function; the `(selectAll)` click handler keeps menu elements hidden through the bookmarklet run and only restores them in a `finally`. Previously the menu was restored before the bookmarklet read the selection, so menu text leaked into the selected string.
- **#23 — Mobile button 100px higher:** New `getTriggerBottomOffsetPx()` returns `180` on `(max-width: 768px)` (else `80`). `applyPositionSetting` uses it for both `right` and `left` presets, and an equivalent CSS media query handles the initial paint before JS runs.

Version bumped to `4.2` (`SCRIPT_VERSION`, `SCRIPT_DATE`, `@version`), v4.1 archived to `previous-versions/35 Universal Bookmarklet Menu-4.1.user.txt`, and a new row added to the README changelog.

## Test plan

- [ ] Desktop: click ✨ SUMMARIZE with no selection → Kagi opens with keypoints view.
- [ ] Desktop: select some text, click ✨ SUMMARIZE → Kagi opens with keypoints view (regression target for #21).
- [ ] Mobile: ✨ SUMMARIZE still opens keypoints view (no regression).
- [ ] Basket → 📚 Summarize Basket → every opened tab uses keypoints.
- [ ] Click `(selectAll)` next to ✨ SUMMARIZE / 💬 Talk to ChatGPT / 🍊 ask Claude / 🔷 Copy Gemini Prompt → the resulting prompt / Kagi text does NOT contain menu item names (e.g. "✨ SUMMARIZE", "🛒 Add to Basket").
- [ ] Mobile browser: the 📟 trigger sits ~100px higher than before and is not obscured by the bottom browser chrome.
- [ ] Desktop browser: trigger position is unchanged from v4.1.
- [ ] Options pane → switch Position between right / left / custom → mobile honors the 180px offset for right/left; custom position still respects dragged coords.

https://claude.ai/code/session_016vW3rcuW3CKaowv8zCBdgJ